### PR TITLE
Remove traces of tgmpa/tgm-plugin-activation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,6 @@ vendor/dealerdirect
 vendor/squizlabs
 vendor/phpcsstandards
 vendor/wp-coding-standards
-vendor/tgmpa/tgm-plugin-activation/plugins
-vendor/tgmpa/tgm-plugin-activation/.editorconfig
-vendor/tgmpa/tgm-plugin-activation/*.md
-vendor/tgmpa/tgm-plugin-activation/*.yml
-vendor/tgmpa/tgm-plugin-activation/*.xml
-vendor/tgmpa/tgm-plugin-activation/example.php
 vendor/wptt/webfont-loader/.gitattributes
 vendor/wptt/webfont-loader/README.md
 vendor/wptt/webfont-loader/LICENSE

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:css": "rm -Rf assets/css && node-sass --output-style compressed --recursive -o assets/css assets/scss && rm -Rf assets/css/abstracts",
     "build:blocks": "cd ../../plugins/blockify-pro && npm run build:pro && cd ../../themes/blockify",
     "build:svg": "node node_modules/oslllo-svg-fixer/src/cli.js -s assets/svg/icon.svg -d assets/svg/optimized",
-    "build:zip": "rm -Rf ../../blockify.zip && zip -r ../../blockify.zip assets/css/ assets/js/ assets/lang/ assets/svg/ includes/ parts/ patterns/ styles/ templates/ vendor/composer vendor/autoload.php vendor/wptt/webfont-loader/wptt-webfont-loader.php vendor/tgmpa/tgm-plugin-activation/languages vendor/tgmpa/tgm-plugin-activation/class-tgm-plugin-activation.php vendor/wptrt/admin-notices/src functions.php index.php readme.txt screenshot.png style.css theme.json",
+    "build:zip": "rm -Rf ../../blockify.zip && zip -r ../../blockify.zip assets/css/ assets/js/ assets/lang/ assets/svg/ includes/ parts/ patterns/ styles/ templates/ vendor/composer vendor/autoload.php vendor/wptt/webfont-loader/wptt-webfont-loader.php vendor/wptrt/admin-notices/src functions.php index.php readme.txt screenshot.png style.css theme.json",
     "build:tag": "npm run build:zip && cd ../../blockify-svn && rm -Rf `ls -td -- */ | head -n 1`* && unzip ../blockify.zip -d `ls -td -- */ | head -n 1`",
     "build:pot": "wp i18n make-pot ./ assets/lang/blockify.pot --exclude='wp,wp-content,vendor,tests'"
   },

--- a/readme.txt
+++ b/readme.txt
@@ -33,10 +33,6 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
-TGMPA
-License: GPL-2.0-or-later
-License URL: https://www.opensource.org/licenses/GPL-2.0
-
 WPTT Webfont Loader
 License: MIT
 License URL: https://opensource.org/licenses/MIT


### PR DESCRIPTION
I could **not** find "Remove TGMPA" in readme.
In which release notes should it be added?
